### PR TITLE
Override ControllerResolver as a shared service

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -43,7 +43,9 @@ class Application extends \Silex\Application
         parent::__construct($values);
 
         // Override the controller resolver with ours
-        $this['resolver'] = new ControllerResolver($this->phpdi);
+        $this['resolver'] = $this->share(function () {
+            return new ControllerResolver($this->phpdi);
+        });
     }
 
     public function offsetGet($id)

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -42,4 +42,15 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('DI\Container', $app->getPhpDi());
     }
+
+    /**
+     * @test
+     */
+    public function the_controller_resolver_should_be_registered_as_a_service()
+    {
+        $app = new Application();
+
+        $this->assertInstanceOf('Closure', $app->raw('resolver'));
+        $this->assertInstanceOf('DI\Bridge\Silex\Controller\ControllerResolver', $app['resolver']);
+    }
 }


### PR DESCRIPTION
I just wanted to give this bridge a try with a Silex 2 project and stumbled upon a bug with the overridden `ControllerResolver` being not registered as a Pimple `service` but as a `parameter`.

As this bridge doesn't support Silex 2/Pimple 3 by default (because there are some breaking changes in Pimple 3 and Silex 2) and I have no Silex 1/Pimple 1 project at hand I cannot surely confirm that this is a bug there too, but as Silex itself registeres its `ControllerResolver` (and every other class) as a (shared) service and not as a parameter I think we should do here, too.

This was the exception I ran into:

```
Fatal error: Uncaught exception 'InvalidArgumentException' with message 'Identifier "resolver" does not contain an object definition.' in \vendor\pimple\pimple\src\Pimple\Container.php:232
Stack trace:
#0 \vendor\silex\silex\src\Silex\Provider\ServiceControllerServiceProvider.php(24): Pimple\Container->extend('resolver', Object(Closure))
#1 \vendor\pimple\pimple\src\Pimple\Container.php(273): Silex\Provider\ServiceControllerServiceProvider->register(Object(Silex\Application))
#2 \vendor\silex\silex\src\Silex\Application.php(132): Pimple\Container->register(Object(Silex\Provider\ServiceControllerServiceProvider), Array)
#3 \src\Silex\Application.php(51): Silex\Application->register(Object(Silex\Provider\ServiceControllerServiceProvider))
#4 \bin\console(14): Silex\Application->__construct('\vendor\pimple\pimple\src\Pimple\Container.php on line 232
```
