### PR TITLE
Refactor ControllerResolver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": ">=5.4",
         "php-di/php-di": "~5.0",
+        "php-di/invoker": "~1.2",
         "silex/silex" : "~1.3",
         "pimple/pimple" : "~1.1"
     },

--- a/tests/Fixture/Application.php
+++ b/tests/Fixture/Application.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace DI\Bridge\Silex\Test\Fixture;
+
+class Application extends \DI\Bridge\Silex\Application
+{
+}

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -66,11 +66,11 @@ class FunctionalTest extends BaseTestCase
     /**
      * @test
      */
-    public function should_pass_request_object()
+    public function should_pass_request_object_by_parameter_name()
     {
         $app = $this->createApplication();
 
-        $app->get('/', function (Request $request) {
+        $app->get('/', function ($request) {
             return 'Hello ' . $request->get('name');
         });
 
@@ -139,5 +139,53 @@ class FunctionalTest extends BaseTestCase
 
         $response = $app->handle(Request::create('/'));
         $this->assertEquals('bar', $response->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function should_pass_the_silex_application_based_on_type_hint()
+    {
+        $app = $this->createApplication();
+        $app['foo'] = 'bar';
+
+        $app->get('/', function (\Silex\Application $a) {
+            return $a['foo'];
+        });
+
+        $response = $app->handle(Request::create('/'));
+        $this->assertEquals('bar', $response->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function should_pass_the_own_application_based_on_type_hint()
+    {
+        $app = new \DI\Bridge\Silex\Test\Fixture\Application(null, [
+            'foo' => 'bar',
+        ]);
+
+        $app->get('/', function (\DI\Bridge\Silex\Test\Fixture\Application $a) {
+            return $a['foo'];
+        });
+
+        $response = $app->handle(Request::create('/'));
+        $this->assertEquals('bar', $response->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function should_pass_request_object_based_on_type_hint()
+    {
+        $app = $this->createApplication();
+
+        $app->get('/', function (Request $r) {
+            return 'Hello ' . $r->get('name');
+        });
+
+        $response = $app->handle(Request::create('/?name=john'));
+        $this->assertEquals('Hello john', $response->getContent());
     }
 }

--- a/tests/ProvidersTest.php
+++ b/tests/ProvidersTest.php
@@ -2,7 +2,9 @@
 
 namespace DI\Bridge\Silex\Test;
 
+use DI\Bridge\Silex\Test\Fixture\Controller;
 use DI\ContainerBuilder;
+use Silex\Provider\ServiceControllerServiceProvider;
 use Silex\Provider\SwiftmailerServiceProvider;
 use Silex\Provider\TwigServiceProvider;
 use Silex\Provider\UrlGeneratorServiceProvider;
@@ -88,5 +90,23 @@ class ProvidersTest extends BaseTestCase
 
         $response = $app->handle(Request::create('/'));
         $this->assertEquals('OK', $response->getContent());
+    }
+
+    /**
+     * @see https://github.com/PHP-DI/Silex-Bridge/issues/7
+     * @test
+     */
+    public function test_service_controller_service_provider()
+    {
+        $app = $this->createApplication();
+
+        $app->register(new ServiceControllerServiceProvider, [
+            'service.controller' => new Controller,
+        ]);
+
+        $app->get('/{name}', 'service.controller:hello');
+
+        $response = $app->handle(Request::create('/john'));
+        $this->assertEquals('Hello john', $response->getContent());
     }
 }


### PR DESCRIPTION
This is needed to support the `ServiceControllerServiceProvider` because it decorates the default `ControllerResolver` and calls `getArguments()` on it.

This commit also enhances compatibility with Silex by allowing to inject
- the Application object by type hint
- the current Request object by type hint
## 

I didn't remove the injection of the `Request` by parameter name because it would be a BC break. But this is not supported by Silex itself and I assume it was done because it was not really possible to inject it via type hinting using the invoker. So I think we should remove it in a later release (maybe with Silex2 support, which I hope will be released soon after Symfony3).

Closes #7
