### PR TITLE
Make this bridge compatible to Silex 1 and 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "php": ">=5.4",
         "php-di/php-di": "~5.0",
         "php-di/invoker": "~1.2",
-        "silex/silex" : "~1.3",
-        "pimple/pimple" : "~1.1"
+        "silex/silex" : "~1.3|2.0.x-dev",
+        "pimple/pimple" : "~1.1|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",

--- a/src/CallbackResolver.php
+++ b/src/CallbackResolver.php
@@ -15,7 +15,7 @@ class CallbackResolver extends \Silex\CallbackResolver
      */
     private $resolver;
 
-    public function __construct(\Pimple $app, CallableResolver $resolver)
+    public function __construct(\Silex\Application $app, CallableResolver $resolver)
     {
         $this->resolver = $resolver;
         parent::__construct($app);

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -8,12 +8,22 @@ use PHPUnit_Framework_TestCase;
 
 class BaseTestCase extends PHPUnit_Framework_TestCase
 {
+    public static function isSilex1(\Silex\Application $app)
+    {
+        return ! self::isSilex2($app);
+    }
+
+    public static function isSilex2(\Silex\Application $app)
+    {
+        return is_subclass_of($app, 'Pimple\Container', false);
+    }
+
     protected function createApplication(ContainerBuilder $builder = null)
     {
         $app = new Application($builder);
 
         $app['debug'] = true;
-        $app['exception_handler']->disable();
+        unset($app['exception_handler']);
 
         return $app;
     }

--- a/tests/PimpleTest.php
+++ b/tests/PimpleTest.php
@@ -29,9 +29,13 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function closures_should_be_factories()
+    public function closures_should_be_factories_in_silex1()
     {
         $app = new Application();
+
+        if (BaseTestCase::isSilex2($app)) {
+            $this->markTestSkipped('Factory services are registered differently in Silex 2.');
+        }
 
         $app['foo'] = function () {
             return new \stdClass();
@@ -44,13 +48,55 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function share_should_share_the_closure_result()
+    public function share_should_share_the_closure_result_in_silex1()
     {
         $app = new Application();
+
+        if (BaseTestCase::isSilex2($app)) {
+            $this->markTestSkipped('Shared services are registered differently in Silex 2.');
+        }
 
         $app['foo'] = $app->share(function () {
             return new \stdClass();
         });
+
+        $this->assertInstanceOf('stdClass', $app['foo']);
+        $this->assertSame($app['foo'], $app['foo']);
+    }
+
+    /**
+     * @test
+     */
+    public function factory_should_create_factory_services_in_silex2()
+    {
+        $app = new Application();
+
+        if (BaseTestCase::isSilex1($app)) {
+            $this->markTestSkipped('Factory services are registered differently in Silex 1.');
+        }
+
+        $app['foo'] = $app->factory(function () {
+            return new \stdClass();
+        });
+
+        $this->assertInstanceOf('stdClass', $app['foo']);
+        $this->assertNotSame($app['foo'], $app['foo']);
+    }
+
+    /**
+     * @test
+     */
+    public function closures_should_be_shared_in_silex2()
+    {
+        $app = new Application();
+
+        if (BaseTestCase::isSilex1($app)) {
+            $this->markTestSkipped('Shared services are registered differently in Silex 1.');
+        }
+
+        $app['foo'] = function () {
+            return new \stdClass();
+        };
 
         $this->assertInstanceOf('stdClass', $app['foo']);
         $this->assertSame($app['foo'], $app['foo']);
@@ -86,10 +132,15 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
     public function extend_should_extend_the_pimple_entry()
     {
         $app = new Application();
-
-        $app['foo'] = $app->share(function () {
+        $service = function () {
             return new \stdClass();
-        });
+        };
+
+        if (BaseTestCase::isSilex1($app)) {
+            $service = $app->share($service);
+        }
+
+        $app['foo'] = $service;
         $app['foo'] = $app->extend('foo', function (\stdClass $previous) {
             $previous->hello = 'world';
             return $previous;

--- a/tests/ProvidersTest.php
+++ b/tests/ProvidersTest.php
@@ -53,7 +53,10 @@ class ProvidersTest extends BaseTestCase
         ]);
         $app = $this->createApplication($builder);
 
-        $app->register(new UrlGeneratorServiceProvider());
+        if (BaseTestCase::isSilex1($app)) {
+            // The url generator is always available in Silex 2.
+            $app->register(new UrlGeneratorServiceProvider());
+        }
 
         $app->get('/', function (UrlGenerator $urlGenerator) {
             return $urlGenerator->generate('home');


### PR DESCRIPTION
I quickly tried to make this bridge compatible with Silex 1 and 2. Because they use different, incompatible versions of Pimple some ugly hacks are needed for this.

The tests don't fail but I haven't tested this in a real project! So maybe someone should try this with a real project first. 
But as this bridge is rather small and Silex itself hasn't very many BC breaks in there API (as far as I know) I don't think theres very much room for errors. The biggest change should be the change in registering services in Pimple itself.

Because I've nearly zero experience in using/configuring Travis CI I have no idea what's needed to make it test this bridge with both Silex versions. Maybe @mnapoli can help here?

closes #6 
