### PR TITLE
Allow arbitrary injection into middleware and param converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $app->run();
 
 Using PHP-DI in Silex allows you to use all the awesome features of PHP-DI to wire your dependencies (using the definition files, autowiring, annotations, …).
 
-Another big benefit of the PHP-DI integration is the ability to use dependency injection inside controllers:
+Another big benefit of the PHP-DI integration is the ability to use dependency injection inside controllers, middlewares and param converters:
 
 ```php
 class Mailer
@@ -51,9 +51,21 @@ $app->post('/register/{name}', function ($name, Mailer $mailer) {
 $app->post('/register/{name}', function (Request $request, Mailer $mailer) {
     // ...
 });
+
+// Injection works for middleware too
+$app->before(function (Request $request, Mailer $mailer) {
+    // ...
+});
+
+// And param converters
+$app->get('/users/{user}', function (User $user) {
+    return new JsonResponse($user);
+})->convert('user', function ($user, UserManager $userManager) {
+    return $userManager->findById($user);
+});
 ```
 
-Dependency injection in controllers works using type-hinting:
+Dependency injection works using type-hinting:
 
 - it can be mixed with request parameters (`$name` in the example above)
 - the order of parameters doesn't matter, they are resolved by type-hint (for dependency injection) and by name (for request attributes)

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.4",
         "php-di/php-di": "~5.0",
-        "php-di/invoker": "~1.2",
+        "php-di/invoker": "~1.3",
         "silex/silex" : "~1.3",
         "pimple/pimple" : "~1.1"
     },

--- a/src/Application.php
+++ b/src/Application.php
@@ -4,10 +4,24 @@ namespace DI\Bridge\Silex;
 
 use DI\Bridge\Silex\Container\ContainerInteropProxy;
 use DI\Bridge\Silex\Controller\ControllerResolver;
+use DI\Bridge\Silex\MiddlewareListener;
+use DI\Bridge\Silex\ConverterListener;
+use Silex\EventListener\LocaleListener;
+use Silex\EventListener\StringToResponseListener;
+use Silex\LazyUrlMatcher;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\ResponseListener;
+use Symfony\Component\HttpKernel\EventListener\RouterListener;
 use DI\Container;
 use DI\ContainerBuilder;
 use Interop\Container\ContainerInterface;
 use Invoker\CallableResolver;
+use Invoker\Reflection\CallableReflection;
 use Invoker\ParameterResolver\AssociativeArrayResolver;
 use Invoker\ParameterResolver\Container\TypeHintContainerResolver;
 use Invoker\ParameterResolver\ResolverChain;
@@ -30,6 +44,11 @@ class Application extends \Silex\Application
     private $phpdi;
 
     /**
+     * @var CallbackInvoker
+     */
+    private $callbackInvoker;
+
+    /**
      * @param ContainerBuilder|null $containerBuilder You can optionally provide your preconfigured container builder.
      * @param array                 $values
      */
@@ -45,6 +64,7 @@ class Application extends \Silex\Application
         ]);
         $containerBuilder->wrapContainer($this->containerInteropProxy);
         $this->phpdi = $containerBuilder->build();
+        $this->callbackInvoker = new CallbackInvoker($this->containerInteropProxy);
 
         parent::__construct($values);
 
@@ -69,6 +89,33 @@ class Application extends \Silex\Application
                 $this,
                 $this['phpdi.callable_resolver']
             );
+        });
+
+        // Override the dispatcher with ours to use our event listeners
+        $this['dispatcher'] = $this->share(function () {
+            /**
+             * @var EventDispatcherInterface
+             */
+            $dispatcher = new $this['dispatcher_class']();
+
+            $urlMatcher = new LazyUrlMatcher(function () {
+                return $this['url_matcher'];
+            });
+            if (Kernel::VERSION_ID >= 20800) {
+                $dispatcher->addSubscriber(new RouterListener($urlMatcher, $this['request_stack'], $this['request_context'], $this['logger']));
+            } else {
+                $dispatcher->addSubscriber(new RouterListener($urlMatcher, $this['request_context'], $this['logger'], $this['request_stack']));
+            }
+            $dispatcher->addSubscriber(new LocaleListener($this, $urlMatcher, $this['request_stack']));
+            if (isset($this['exception_handler'])) {
+                $dispatcher->addSubscriber($this['exception_handler']);
+            }
+            $dispatcher->addSubscriber(new ResponseListener($this['charset']));
+            $dispatcher->addSubscriber(new MiddlewareListener($this, $this->callbackInvoker));
+            $dispatcher->addSubscriber(new ConverterListener($this['routes'], $this['callback_resolver'], $this->callbackInvoker));
+            $dispatcher->addSubscriber(new StringToResponseListener());
+
+            return $dispatcher;
         });
     }
 
@@ -99,5 +146,84 @@ class Application extends \Silex\Application
     public function getPhpDi()
     {
         return $this->phpdi;
+    }
+
+    public function before($callback, $priority = 0)
+    {
+        $this->on(KernelEvents::REQUEST, function (GetResponseEvent $event) use ($callback) {
+            if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
+                return;
+            }
+
+            $request = $event->getRequest();
+            $middleware = $this['callback_resolver']->resolveCallback($callback);
+            $ret = $this->callbackInvoker->call($middleware, [
+                // type hints
+                'Symfony\Component\HttpFoundation\Request' => $request,
+                // Silex' default parameter order
+                0 => $request,
+                1 => $this,
+            ]);
+
+            if ($ret instanceof Response) {
+                $event->setResponse($ret);
+            }
+
+        }, $priority);
+    }
+
+    public function after($callback, $priority = 0)
+    {
+        $this->on(KernelEvents::RESPONSE, function (FilterResponseEvent $event) use ($callback) {
+            if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
+                return;
+            }
+
+            $request = $event->getRequest();
+            $response = $event->getResponse();
+            $middleware = $this['callback_resolver']->resolveCallback($callback);
+            $ret = $this->callbackInvoker->call($middleware, [
+                // type hints
+                'Symfony\Component\HttpFoundation\Request' => $request,
+                'Symfony\Component\HttpFoundation\Response' => $response,
+                // Silex' default parameter order
+                0 => $request,
+                1 => $response,
+                2 => $this,
+            ]);
+
+            if ($ret instanceof Response) {
+                $event->setResponse($ret);
+            } elseif (null !== $ret) {
+                throw new \RuntimeException('An after middleware returned an invalid response value. Must return null or an instance of Response.');
+            }
+
+        }, $priority);
+    }
+
+    public function finish($callback, $priority = 0)
+    {
+        $this->on(KernelEvents::TERMINATE, function (PostResponseEvent $event) use ($callback) {
+
+            $request = $event->getRequest();
+            $response = $event->getResponse();
+            $middleware = $this['callback_resolver']->resolveCallback($callback);
+            $ret = $this->callbackInvoker->call($middleware, [
+                // type hints
+                'Symfony\Component\HttpFoundation\Request' => $request,
+                'Symfony\Component\HttpFoundation\Response' => $response,
+                // Silex' default parameter order
+                0 => $request,
+                1 => $response,
+                2 => $this,
+            ]);
+
+            if ($ret instanceof Response) {
+                $event->setResponse($ret);
+            } elseif (null !== $ret) {
+                throw new \RuntimeException('An after middleware returned an invalid response value. Must return null or an instance of Response.');
+            }
+
+        }, $priority);
     }
 }

--- a/src/CallbackInvoker.php
+++ b/src/CallbackInvoker.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DI\Bridge\Silex;
+
+use DI\Bridge\Silex\Application;
+use Invoker\Invoker;
+use Interop\Container\ContainerInterface;
+use Invoker\ParameterResolver\ResolverChain;
+use Invoker\ParameterResolver\TypeHintResolver;
+use Invoker\ParameterResolver\AssociativeArrayResolver;
+use Invoker\ParameterResolver\Container\TypeHintContainerResolver;
+use Invoker\ParameterResolver\NumericArrayResolver;
+
+/**
+ * A subclass of Invoker that always tries to first resolve through provided parameter names, then
+ * type hints, then through the DI container and finally allows a fallback to a default parameter order
+ *
+ * @author Felix Becker <f.becker@outlook.com>
+ */
+class CallbackInvoker extends Invoker
+{
+    /**
+     * @param ContainerInterface $container the container for injection
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        parent::__construct(new ResolverChain([
+            new AssociativeArrayResolver,
+            new TypeHintResolver,
+            new TypeHintContainerResolver($container),
+            new NumericArrayResolver,
+        ]));
+    }
+}

--- a/src/ConverterListener.php
+++ b/src/ConverterListener.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace DI\Bridge\Silex;
+
+use DI\Bridge\Silex\CallbackResolver;
+use Interop\Container\ContainerInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Replacement for the Silex ConverterListener to allow arbitrary injection into param converters.
+ *
+ * @author Felix Becker <f.becker@outlook.com>
+ */
+class ConverterListener extends \Silex\EventListener\ConverterListener
+{
+    /**
+     * @var CallbackInvoker
+     */
+    private $callbackInvoker;
+
+    /**
+     * @param RouteCollection  $routes           A RouteCollection instance
+     * @param CallbackResolver $callbackResolver A CallbackResolver instance
+     * @param CallbackInvoker  $callbackInvoker  The invoker that handles resolving and injecting param converters
+     */
+    public function __construct(RouteCollection $routes, CallbackResolver $callbackResolver, CallbackInvoker $callbackInvoker)
+    {
+        parent::__construct($routes, $callbackResolver);
+        $this->callbackInvoker = $callbackInvoker;
+    }
+
+    public function onKernelController(FilterControllerEvent $event)
+    {
+        $request = $event->getRequest();
+        $route = $this->routes->get($request->attributes->get('_route'));
+        if ($route && $converters = $route->getOption('_converters')) {
+            foreach ($converters as $name => $callback) {
+
+                $value = $request->attributes->get($name);
+                $middleware = $this->callbackResolver->resolveCallback($callback);
+                $ret = $this->callbackInvoker->call($middleware, [
+                    // parameter name
+                    $name => $value,
+                    // type hints
+                    'Symfony\Component\HttpFoundation\Request' => $request,
+                    // Silex' default parameter order
+                    0 => $value,
+                    1 => $request,
+                ]);
+
+                $request->attributes->set($name, $ret);
+            }
+        }
+    }
+}

--- a/src/MiddlewareListener.php
+++ b/src/MiddlewareListener.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace DI\Bridge\Silex;
+
+use DI\Bridge\Silex\Application;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Replacement for the Silex MiddlewareListener to allow arbitrary injection into middleware functions.
+ *
+ * @author Felix Becker <f.becker@outlook.com>
+ */
+class MiddlewareListener extends \Silex\EventListener\MiddlewareListener
+{
+    /**
+     * @var CallbackInvoker
+     */
+    private $callbackInvoker;
+
+    /**
+     * @param Application     $app             The application
+     * @param CallbackInvoker $callbackInvoker The invoker that handles injecting middlewares
+     */
+    public function __construct(Application $app, CallbackInvoker $callbackInvoker)
+    {
+        parent::__construct($app);
+        $this->callbackInvoker = $callbackInvoker;
+    }
+
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+        $routeName = $request->attributes->get('_route');
+        if (!$route = $this->app['routes']->get($routeName)) {
+            return;
+        }
+
+        foreach ((array) $route->getOption('_before_middlewares') as $callback) {
+
+            $middleware = $this->app['callback_resolver']->resolveCallback($callback);
+            $ret = $this->callbackInvoker->call($middleware, [
+                // type hints
+                'Symfony\Component\HttpFoundation\Request' => $request,
+                // Silex' default parameter order
+                0 => $request,
+                1 => $this->app,
+            ]);
+
+            if ($ret instanceof Response) {
+                $event->setResponse($ret);
+            } elseif (null !== $ret) {
+                throw new \RuntimeException(sprintf('A before middleware for route "%s" returned an invalid response value. Must return null or an instance of Response.', $routeName));
+            }
+        }
+    }
+
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        $request = $event->getRequest();
+        $response = $event->getResponse();
+        $routeName = $request->attributes->get('_route');
+        if (!$route = $this->app['routes']->get($routeName)) {
+            return;
+        }
+
+        foreach ((array) $route->getOption('_after_middlewares') as $callback) {
+
+            $middleware = $this->app['callback_resolver']->resolveCallback($callback);
+            $ret = $this->callbackInvoker->call($middleware, [
+                // type hints
+                'Symfony\Component\HttpFoundation\Request' => $request,
+                'Symfony\Component\HttpFoundation\Response' => $response,
+                // Silex' default parameter order
+                0 => $request,
+                1 => $response,
+                2 => $this->app,
+            ]);
+
+            if ($ret instanceof Response) {
+                $event->setResponse($ret);
+            } elseif (null !== $ret) {
+                throw new \RuntimeException(sprintf('An after middleware for route "%s" returned an invalid response value. Must return null or an instance of Response.', $routeName));
+            }
+        }
+    }
+}

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace DI\Bridge\Silex\Test;
+
+use DI\ContainerBuilder;
+
+use stdClass;
+use DI\Bridge\Silex\Application;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ConverterTest extends BaseTestCase
+{
+    /**
+     * @test
+     */
+    public function should_allow_arbitrary_injection_in_converter()
+    {
+        $builder = new ContainerBuilder;
+        $builder->addDefinitions([
+            'stdClass' => function () {
+                $service = new stdClass;
+                $service->foo = 'bar';
+                return $service;
+            },
+        ]);
+
+        $application = $this->createApplication($builder);
+
+        $request = Request::create('/john?some=param');
+
+        $converter = function (Request $req, Application $app, stdClass $someService, $user) use ($application) {
+            $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Request', $req);
+            $this->assertEquals('param', $req->query->get('some'));
+            $this->assertEquals($application, $app);
+            $this->assertInstanceOf('stdClass', $someService);
+            $this->assertAttributeEquals('bar', 'foo', $someService);
+            $this->assertEquals($user, 'john');
+            return ['name' => $user];
+        };
+
+        $handler = function (Request $r, array $user) {
+            return 'Hello ' . $user['name'];
+        };
+
+        $application->get('/{user}', $handler)->convert('user', $converter);
+
+        $response = $application->handle($request);
+        $this->assertEquals('Hello john', $response->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function should_fall_back_to_silex_default_behaviour()
+    {
+        $application = $this->createApplication();
+
+        $request = Request::create('/john?some=param');
+
+        $converter = function ($user, $req) use ($application) {
+            $this->assertEquals($user, 'john');
+            $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Request', $req);
+            $this->assertEquals('param', $req->query->get('some'));
+            return ['name' => $user];
+        };
+
+        $handler = function (Request $r, array $user) {
+            return 'Hello ' . $user['name'];
+        };
+
+        $application->get('/{user}', $handler)->convert('user', $converter);
+
+        $response = $application->handle($request);
+        $this->assertEquals('Hello john', $response->getContent());
+    }
+}

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace DI\Bridge\Silex\Test;
+
+use DI\ContainerBuilder;
+
+use stdClass;
+use DI\Bridge\Silex\Application;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class MiddlewareTest extends BaseTestCase
+{
+    /**
+     * @test
+     */
+    public function should_allow_arbitrary_injection_in_middleware()
+    {
+        $builder = new ContainerBuilder;
+        $builder->addDefinitions([
+            'stdClass' => function () {
+                $service = new stdClass;
+                $service->foo = 'bar';
+                return $service;
+            },
+        ]);
+
+        $application = $this->createApplication($builder);
+
+        $request = Request::create('/?name=john');
+
+        $afterMiddleware = function (Application $app, Response $res, Request $req, stdClass $someService) use ($application) {
+            $this->assertEquals($application, $app);
+            $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $res);
+            $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Request', $req);
+            $this->assertEquals('john', $req->query->get('name'));
+            $this->assertInstanceOf('stdClass', $someService);
+            $this->assertAttributeEquals('bar', 'foo', $someService);
+        };
+
+        $beforeMiddleware = function (Application $app, Request $req, stdClass $someService) use ($application) {
+            $this->assertEquals($application, $app);
+            $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Request', $req);
+            $this->assertEquals('john', $req->query->get('name'));
+            $this->assertInstanceOf('stdClass', $someService);
+            $this->assertAttributeEquals('bar', 'foo', $someService);
+        };
+
+        $handler = function (Request $r) {
+            return 'Hello ' . $r->get('name');
+        };
+
+        // route middleware
+        $application->get('/', $handler)->before($beforeMiddleware)->after($afterMiddleware);
+
+        // application middleware
+        $application->before($beforeMiddleware);
+        $application->after($afterMiddleware);
+        $application->finish($afterMiddleware);
+
+        $response = $application->handle($request);
+        $this->assertEquals('Hello john', $response->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function should_fall_back_to_silex_default_behaviour()
+    {
+        $application = $this->createApplication();
+
+        $request = Request::create('/?name=john');
+
+        $beforeMiddleware = function ($req, $app) use ($application) {
+            $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Request', $req);
+            $this->assertEquals('john', $req->query->get('name'));
+            $this->assertEquals($application, $app);
+        };
+
+        $afterMiddleware = function ($req, $res, $app) use ($application) {
+            $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Request', $req);
+            $this->assertEquals('john', $req->query->get('name'));
+            $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $res);
+            $this->assertEquals($application, $app);
+        };
+
+        $handler = function (Request $req) {
+            return 'Hello ' . $req->get('name');
+        };
+
+        // route middleware
+        $application->get('/', $handler)->before($beforeMiddleware)->after($afterMiddleware);
+
+        // application middleware
+        $application->before($beforeMiddleware);
+        $application->after($afterMiddleware);
+        $application->finish($afterMiddleware);
+
+        $response = $application->handle($request);
+        $this->assertEquals('Hello john', $response->getContent());
+    }
+}


### PR DESCRIPTION
This is an implementation for #15
I would love to get this merged as quickly as possible to depend on it in my projects.

---
### Feature

It is now possible to inject whatever is registered in the container into route param converters and middleware via type hints. Also, as long as the arguments are type-hinted, argument position of request / response / app doesn't matter anymore. If there are no type-hints, it falls back to Silex' default argument order.
### Implementation

To accomplish this, `ConverterListener` and `MiddlewareListener` are overwritten and in `Application` the default dispatcher is overwritten to use the custom classes. For application middleware, `before`/`after`/`finish` are overwritten aswell.

For DRY reasons the injection logic is done in separate classes (`BeforeMiddlewareCaller`, `AfterMiddlewareCaller`, `ConverterCaller`). This allows the application middleware and route middleware to share the same logic and also for all event listeners to share the same instance of the caller and `ParameterResolver` objects.
### Tests

`ConverterTest` and `MiddlewareTest` test that both arbitrary injection is possible and the old behaviour still works.
### Docs

I altered the README to highlight that injection works not only for controllers but also for converters and middleware and added two examples.
### BC Breaks

None

---

Any thoughts / objections?
