### PR TITLE
[Silex2] Cleanup

### DIFF
--- a/src/CallbackInvoker.php
+++ b/src/CallbackInvoker.php
@@ -2,25 +2,24 @@
 
 namespace DI\Bridge\Silex;
 
-use DI\Bridge\Silex\Application;
-use Invoker\Invoker;
 use Interop\Container\ContainerInterface;
-use Invoker\ParameterResolver\ResolverChain;
-use Invoker\ParameterResolver\TypeHintResolver;
+use Invoker\Invoker;
 use Invoker\ParameterResolver\AssociativeArrayResolver;
 use Invoker\ParameterResolver\Container\TypeHintContainerResolver;
 use Invoker\ParameterResolver\NumericArrayResolver;
+use Invoker\ParameterResolver\ResolverChain;
+use Invoker\ParameterResolver\TypeHintResolver;
 
 /**
  * A subclass of Invoker that always tries to first resolve through provided parameter names, then
- * type hints, then through the DI container and finally allows a fallback to a default parameter order
+ * type hints, then through the DI container and finally allows a fallback to a default parameter order.
  *
  * @author Felix Becker <f.becker@outlook.com>
  */
 class CallbackInvoker extends Invoker
 {
     /**
-     * @param ContainerInterface $container the container for injection
+     * @param ContainerInterface $container The container for injection
      */
     public function __construct(ContainerInterface $container)
     {

--- a/src/ConverterListener.php
+++ b/src/ConverterListener.php
@@ -2,8 +2,7 @@
 
 namespace DI\Bridge\Silex;
 
-use DI\Bridge\Silex\CallbackResolver;
-use Interop\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -36,14 +35,13 @@ class ConverterListener extends \Silex\EventListener\ConverterListener
         $route = $this->routes->get($request->attributes->get('_route'));
         if ($route && $converters = $route->getOption('_converters')) {
             foreach ($converters as $name => $callback) {
-
                 $value = $request->attributes->get($name);
                 $middleware = $this->callbackResolver->resolveCallback($callback);
                 $ret = $this->callbackInvoker->call($middleware, [
                     // parameter name
                     $name => $value,
                     // type hints
-                    'Symfony\Component\HttpFoundation\Request' => $request,
+                    Request::class => $request,
                     // Silex' default parameter order
                     0 => $value,
                     1 => $request,

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -3,7 +3,11 @@
 namespace DI\Bridge\Silex\Test;
 
 use DI\Bridge\Silex\Application;
+use DI\Bridge\Silex\CallbackResolver;
+use DI\Bridge\Silex\Controller\ControllerResolver;
+use DI\Container;
 use DI\ContainerBuilder;
+use Interop\Container\ContainerInterface;
 
 class ApplicationTest extends \PHPUnit_Framework_TestCase
 {
@@ -30,7 +34,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $this->assertInstanceOf('Interop\Container\ContainerInterface', $app->getContainer());
+        $this->assertInstanceOf(ContainerInterface::class, $app->getContainer());
     }
 
     /**
@@ -40,7 +44,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $this->assertInstanceOf('DI\Container', $app->getPhpDi());
+        $this->assertInstanceOf(Container::class, $app->getPhpDi());
     }
 
     /**
@@ -50,8 +54,8 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $this->assertInstanceOf('Closure', $app->raw('resolver'));
-        $this->assertInstanceOf('DI\Bridge\Silex\Controller\ControllerResolver', $app['resolver']);
+        $this->assertInstanceOf(\Closure::class, $app->raw('resolver'));
+        $this->assertInstanceOf(ControllerResolver::class, $app['resolver']);
     }
 
     /**
@@ -61,7 +65,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $this->assertInstanceOf('Closure', $app->raw('callback_resolver'));
-        $this->assertInstanceOf('DI\Bridge\Silex\CallbackResolver', $app['callback_resolver']);
+        $this->assertInstanceOf(\Closure::class, $app->raw('callback_resolver'));
+        $this->assertInstanceOf(CallbackResolver::class, $app['callback_resolver']);
     }
 }

--- a/tests/CallbackResolverTest.php
+++ b/tests/CallbackResolverTest.php
@@ -58,7 +58,7 @@ class CallbackResolverTest extends BaseTestCase
     {
         $app = new Application();
 
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->setExpectedException(\InvalidArgumentException::class);
         $app['callback_resolver']->resolveCallback('some.service');
     }
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -2,6 +2,8 @@
 
 namespace DI\Bridge\Silex\Test;
 
+use Silex\Route;
+
 class ContainerTest extends BaseTestCase
 {
     /**
@@ -35,6 +37,6 @@ class ContainerTest extends BaseTestCase
         // Get from PHP-DI into Pimple
         $container->set('foo', \DI\get('route_class'));
 
-        $this->assertEquals('Silex\Route', $container->get('foo'));
+        $this->assertEquals(Route::class, $container->get('foo'));
     }
 }

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -2,12 +2,10 @@
 
 namespace DI\Bridge\Silex\Test;
 
-use DI\ContainerBuilder;
-
-use stdClass;
 use DI\Bridge\Silex\Application;
+use DI\ContainerBuilder;
+use stdClass;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 class ConverterTest extends BaseTestCase
 {
@@ -30,7 +28,7 @@ class ConverterTest extends BaseTestCase
         $request = Request::create('/john?some=param');
 
         $converter = function (Request $req, Application $app, stdClass $someService, $user) use ($application) {
-            $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Request', $req);
+            $this->assertInstanceOf(Request::class, $req);
             $this->assertEquals('param', $req->query->get('some'));
             $this->assertEquals($application, $app);
             $this->assertInstanceOf('stdClass', $someService);
@@ -60,7 +58,7 @@ class ConverterTest extends BaseTestCase
 
         $converter = function ($user, $req) use ($application) {
             $this->assertEquals($user, 'john');
-            $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Request', $req);
+            $this->assertInstanceOf(Request::class, $req);
             $this->assertEquals('param', $req->query->get('some'));
             return ['name' => $user];
         };

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -31,7 +31,7 @@ class FunctionalTest extends BaseTestCase
     {
         $app = $this->createApplication();
 
-        $app->get('/foo', 'DI\Bridge\Silex\Test\Fixture\InvokableController');
+        $app->get('/foo', Fixture\InvokableController::class);
 
         $response = $app->handle(Request::create('/foo'));
         $this->assertEquals('Hello world', $response->getContent());
@@ -44,7 +44,7 @@ class FunctionalTest extends BaseTestCase
     {
         $app = $this->createApplication();
 
-        $app->get('/foo', ['DI\Bridge\Silex\Test\Fixture\Controller', 'home']);
+        $app->get('/foo', [Fixture\Controller::class, 'home']);
 
         $response = $app->handle(Request::create('/foo'));
         $this->assertEquals('Hello world', $response->getContent());
@@ -57,7 +57,7 @@ class FunctionalTest extends BaseTestCase
     {
         $app = $this->createApplication();
 
-        $app->get('/{name}', ['DI\Bridge\Silex\Test\Fixture\Controller', 'hello']);
+        $app->get('/{name}', [Fixture\Controller::class, 'hello']);
 
         $response = $app->handle(Request::create('/john'));
         $this->assertEquals('Hello john', $response->getContent());
@@ -162,11 +162,11 @@ class FunctionalTest extends BaseTestCase
      */
     public function should_pass_the_own_application_based_on_type_hint()
     {
-        $app = new \DI\Bridge\Silex\Test\Fixture\Application(null, [
+        $app = new Fixture\Application(null, [
             'foo' => 'bar',
         ]);
 
-        $app->get('/', function (\DI\Bridge\Silex\Test\Fixture\Application $a) {
+        $app->get('/', function (Fixture\Application $a) {
             return $a['foo'];
         });
 
@@ -196,8 +196,8 @@ class FunctionalTest extends BaseTestCase
     {
         $app = $this->createApplication();
 
-        $app->get('/{user}', 'DI\Bridge\Silex\Test\Fixture\HelloController')
-            ->convert('user', 'DI\Bridge\Silex\Test\Fixture\InvokableConverter');
+        $app->get('/{user}', Fixture\HelloController::class)
+            ->convert('user', Fixture\InvokableConverter::class);
 
         $response = $app->handle(Request::create('/PHPDI'));
         $this->assertEquals('PHPDI', $response->getContent());
@@ -210,8 +210,8 @@ class FunctionalTest extends BaseTestCase
     {
         $app = $this->createApplication();
 
-        $app->get('/', 'DI\Bridge\Silex\Test\Fixture\InvokableController')
-            ->before('DI\Bridge\Silex\Test\Fixture\InvokableMiddleware');
+        $app->get('/', Fixture\InvokableController::class)
+            ->before(Fixture\InvokableMiddleware::class);
 
         $response = $app->handle(Request::create('/'));
         $this->assertEquals('Hello from middleware', $response->getContent());
@@ -224,7 +224,7 @@ class FunctionalTest extends BaseTestCase
     {
         $app = $this->createApplication();
 
-        $app->error('DI\Bridge\Silex\Test\Fixture\InvokableErrorListener');
+        $app->error(Fixture\InvokableErrorListener::class);
 
         $response = $app->handle(Request::create('/'));
         $this->assertEquals('Sad panda :(', $response->getContent());
@@ -237,9 +237,9 @@ class FunctionalTest extends BaseTestCase
     {
         $app = $this->createApplication();
 
-        $app->get('/', 'DI\Bridge\Silex\Test\Fixture\InvokableController');
+        $app->get('/', Fixture\InvokableController::class);
 
-        $app->view('DI\Bridge\Silex\Test\Fixture\InvokableViewListener');
+        $app->view(Fixture\InvokableViewListener::class);
 
         $response = $app->handle(Request::create('/'));
         $this->assertEquals('Hello world from mars', $response->getContent());

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -2,10 +2,9 @@
 
 namespace DI\Bridge\Silex\Test;
 
-use DI\ContainerBuilder;
-
-use stdClass;
 use DI\Bridge\Silex\Application;
+use DI\ContainerBuilder;
+use stdClass;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -31,8 +30,8 @@ class MiddlewareTest extends BaseTestCase
 
         $afterMiddleware = function (Application $app, Response $res, Request $req, stdClass $someService) use ($application) {
             $this->assertEquals($application, $app);
-            $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $res);
-            $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Request', $req);
+            $this->assertInstanceOf(Response::class, $res);
+            $this->assertInstanceOf(Request::class, $req);
             $this->assertEquals('john', $req->query->get('name'));
             $this->assertInstanceOf('stdClass', $someService);
             $this->assertAttributeEquals('bar', 'foo', $someService);
@@ -40,7 +39,7 @@ class MiddlewareTest extends BaseTestCase
 
         $beforeMiddleware = function (Application $app, Request $req, stdClass $someService) use ($application) {
             $this->assertEquals($application, $app);
-            $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Request', $req);
+            $this->assertInstanceOf(Request::class, $req);
             $this->assertEquals('john', $req->query->get('name'));
             $this->assertInstanceOf('stdClass', $someService);
             $this->assertAttributeEquals('bar', 'foo', $someService);
@@ -72,15 +71,15 @@ class MiddlewareTest extends BaseTestCase
         $request = Request::create('/?name=john');
 
         $beforeMiddleware = function ($req, $app) use ($application) {
-            $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Request', $req);
+            $this->assertInstanceOf(Request::class, $req);
             $this->assertEquals('john', $req->query->get('name'));
             $this->assertEquals($application, $app);
         };
 
         $afterMiddleware = function ($req, $res, $app) use ($application) {
-            $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Request', $req);
+            $this->assertInstanceOf(Request::class, $req);
             $this->assertEquals('john', $req->query->get('name'));
-            $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $res);
+            $this->assertInstanceOf(Response::class, $res);
             $this->assertEquals($application, $app);
         };
 

--- a/tests/ProvidersTest.php
+++ b/tests/ProvidersTest.php
@@ -7,10 +7,6 @@ use DI\ContainerBuilder;
 use Silex\Provider\ServiceControllerServiceProvider;
 use Silex\Provider\SwiftmailerServiceProvider;
 use Silex\Provider\TwigServiceProvider;
-use Silex\Provider\UrlGeneratorServiceProvider;
-use Swift_Events_SimpleEventDispatcher;
-use Swift_Mailer;
-use Swift_Transport_NullTransport;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 
@@ -24,11 +20,11 @@ class ProvidersTest extends BaseTestCase
         $builder = new ContainerBuilder;
         $builder->addDefinitions([
             // Create an alias so that we can inject with the type-hint
-            'Twig_Environment' => \DI\get('twig'),
+            \Twig_Environment::class => \DI\get('twig'),
         ]);
         $app = $this->createApplication($builder);
 
-        $app->register(new TwigServiceProvider(), [
+        $app->register(new TwigServiceProvider, [
             'twig.path' => __DIR__ . '/Fixture/views',
         ]);
 
@@ -49,7 +45,7 @@ class ProvidersTest extends BaseTestCase
         $builder = new ContainerBuilder;
         $builder->addDefinitions([
             // Create an alias so that we can inject with the type-hint
-            'Symfony\Component\Routing\Generator\UrlGenerator' => \DI\get('url_generator'),
+            UrlGenerator::class => \DI\get('url_generator'),
         ]);
         $app = $this->createApplication($builder);
 
@@ -70,17 +66,17 @@ class ProvidersTest extends BaseTestCase
         $builder = new ContainerBuilder;
         $builder->addDefinitions([
             // Create an alias so that we can inject with the type-hint
-            'Swift_Mailer' => \DI\get('mailer'),
+            \Swift_Mailer::class => \DI\get('mailer'),
         ]);
         $app = $this->createApplication($builder);
 
         $app->register(new SwiftmailerServiceProvider, [
-            'swiftmailer.transport' => new Swift_Transport_NullTransport(
-                new Swift_Events_SimpleEventDispatcher
+            'swiftmailer.transport' => new \Swift_Transport_NullTransport(
+                new \Swift_Events_SimpleEventDispatcher
             ),
         ]);
 
-        $app->get('/', function (Swift_Mailer $mailer) {
+        $app->get('/', function (\Swift_Mailer $mailer) {
             $message = \Swift_Message::newInstance();
             $mailer->send($message);
             return 'OK';


### PR DESCRIPTION
Since Silex 2 requires PHP >= 5.5 we can now use `::class`.
I also fixed some small typos and removed some unused imports.
