### PR TITLE
Allow short circuiting the controller in a before middleware

### DIFF
--- a/src/MiddlewareListener.php
+++ b/src/MiddlewareListener.php
@@ -2,10 +2,9 @@
 
 namespace DI\Bridge\Silex;
 
-use DI\Bridge\Silex\Application;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 /**
  * Replacement for the Silex MiddlewareListener to allow arbitrary injection into middleware functions.
@@ -21,7 +20,7 @@ class MiddlewareListener extends \Silex\EventListener\MiddlewareListener
 
     /**
      * @param Application     $app             The application
-     * @param CallbackInvoker $callbackInvoker The invoker that handles injecting middlewares
+     * @param CallbackInvoker $callbackInvoker The invoker that handles injecting middleware
      */
     public function __construct(Application $app, CallbackInvoker $callbackInvoker)
     {
@@ -38,7 +37,6 @@ class MiddlewareListener extends \Silex\EventListener\MiddlewareListener
         }
 
         foreach ((array) $route->getOption('_before_middlewares') as $callback) {
-
             $middleware = $this->app['callback_resolver']->resolveCallback($callback);
             $ret = $this->callbackInvoker->call($middleware, [
                 // type hints
@@ -50,6 +48,8 @@ class MiddlewareListener extends \Silex\EventListener\MiddlewareListener
 
             if ($ret instanceof Response) {
                 $event->setResponse($ret);
+
+                return;
             } elseif (null !== $ret) {
                 throw new \RuntimeException(sprintf('A before middleware for route "%s" returned an invalid response value. Must return null or an instance of Response.', $routeName));
             }
@@ -66,7 +66,6 @@ class MiddlewareListener extends \Silex\EventListener\MiddlewareListener
         }
 
         foreach ((array) $route->getOption('_after_middlewares') as $callback) {
-
             $middleware = $this->app['callback_resolver']->resolveCallback($callback);
             $ret = $this->callbackInvoker->call($middleware, [
                 // type hints

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -103,6 +103,34 @@ class MiddlewareTest extends BaseTestCase
     /**
      * @test
      */
+    public function should_allow_short_circuiting_the_controller_in_before_application_middleware()
+    {
+        $application = $this->createApplication();
+        $request = Request::create('/');
+
+        $shouldBeCalled = $this->createSpyCallback();
+        $shouldBeCalled->expects($this->once())->method('__invoke');
+
+        $shouldNotBeCalled = $this->createSpyCallback();
+        $shouldNotBeCalled->expects($this->never())->method('__invoke');
+
+        $application->get('/', $shouldNotBeCalled);
+
+        // application middleware
+        $application->before(function () {
+            return new Response('Expected result');
+        });
+        $application->before($shouldNotBeCalled);
+        $application->after($shouldBeCalled);
+        $application->finish($shouldBeCalled);
+
+        $response = $application->handle($request);
+        $this->assertEquals('Expected result', $response->getContent());
+    }
+
+    /**
+     * @test
+     */
     public function should_allow_short_circuiting_the_controller_in_before_route_middleware()
     {
         $application = $this->createApplication();


### PR DESCRIPTION
This brings the bridge in line with the behavior of Silex.

fixes #19
