### PR TITLE
Replace the original Symfony EventDispatcher

### DIFF
--- a/src/CallbackInvoker.php
+++ b/src/CallbackInvoker.php
@@ -28,6 +28,6 @@ class CallbackInvoker extends Invoker
             new TypeHintResolver,
             new TypeHintContainerResolver($container),
             new NumericArrayResolver,
-        ]));
+        ]), $container);
     }
 }

--- a/src/EventDispatcher/EventDispatcher.php
+++ b/src/EventDispatcher/EventDispatcher.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace DI\Bridge\Silex\EventDispatcher;
+
+use DI\Bridge\Silex\CallbackInvoker;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Replacement for the Symfony EventDispatcher to allow arbitrary injection into event listeners.
+ *
+ * @author Bram Van der Sype <bram.vandersype@gmail.com>
+ */
+class EventDispatcher extends \Symfony\Component\EventDispatcher\EventDispatcher
+{
+    /**
+     * @var CallbackInvoker
+     */
+    private $callbackInvoker;
+
+    /**
+     * @param CallbackInvoker $callbackInvoker
+     */
+    public function __construct(CallbackInvoker $callbackInvoker)
+    {
+        $this->callbackInvoker = $callbackInvoker;
+    }
+
+    /**
+     * @param \callable[] $listeners
+     * @param string $eventName
+     * @param Event $event
+     */
+    protected function doDispatch($listeners, $eventName, Event $event)
+    {
+        foreach ($listeners as $listener) {
+            if ($event->isPropagationStopped()) {
+                break;
+            }
+            
+            $this->callbackInvoker->call($listener, [
+                'event' => $event,
+                0 => $event,
+                1 => $eventName,
+                2 => $this
+            ]);
+        }
+    }
+
+}

--- a/src/Provider/HttpKernelServiceProvider.php
+++ b/src/Provider/HttpKernelServiceProvider.php
@@ -6,6 +6,7 @@ use DI\Bridge\Silex\CallbackInvoker;
 use DI\Bridge\Silex\CallbackResolver;
 use DI\Bridge\Silex\Controller\ControllerResolver;
 use DI\Bridge\Silex\ConverterListener;
+use DI\Bridge\Silex\EventDispatcher\EventDispatcher;
 use DI\Bridge\Silex\MiddlewareListener;
 use Interop\Container\ContainerInterface;
 use Invoker\ParameterResolver\AssociativeArrayResolver;
@@ -60,6 +61,11 @@ class HttpKernelServiceProvider implements ServiceProviderInterface, EventListen
                 $app,
                 $app['phpdi.callable_resolver']
             );
+        };
+
+        // Override the event dispatcher with ours.
+        $app['dispatcher'] = function () {
+            return new EventDispatcher($this->callbackInvoker);
         };
     }
 

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -5,6 +5,7 @@ namespace DI\Bridge\Silex\Test;
 use DI\Bridge\Silex\Application;
 use DI\Bridge\Silex\CallbackResolver;
 use DI\Bridge\Silex\Controller\ControllerResolver;
+use DI\Bridge\Silex\EventDispatcher\EventDispatcher;
 use DI\Container;
 use DI\ContainerBuilder;
 use Interop\Container\ContainerInterface;
@@ -67,5 +68,15 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(\Closure::class, $app->raw('callback_resolver'));
         $this->assertInstanceOf(CallbackResolver::class, $app['callback_resolver']);
+    }
+
+    /**
+     * @test
+     */
+    public function the_event_dispatcher_should_be_ours()
+    {
+        $app = new Application();
+        
+        $this->assertInstanceOf(EventDispatcher::class, $app['dispatcher']);
     }
 }


### PR DESCRIPTION
Now uses an implementation that uses callbackInvoker
